### PR TITLE
Eager-load lib directory as well as autoloading

### DIFF
--- a/lib/blockly_interpreter/engine.rb
+++ b/lib/blockly_interpreter/engine.rb
@@ -4,5 +4,6 @@ module BlocklyInterpreter
     isolate_namespace BlocklyInterpreter
 
     config.autoload_paths += Dir["#{config.root}/lib/**/"]
+    config.eager_load_paths += Dir["#{config.root}/lib/**/"]
   end
 end


### PR DESCRIPTION
With Rails 5, autoloading is now completely disabled in environments where config.eager_load = true. Any files outside of `/app` that are added to `config.autoload_paths` should also be added to `config.eager_load_paths`.